### PR TITLE
📝 docs(js-sdk): enumerate allowed values for hosted-field styles object

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,23 +13,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Saving cache
-        uses: actions/cache@v2
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
+        uses: actions/checkout@v4
 
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: 'https://npm.pkg.github.com'
+          cache: 'npm'
 
       - name: Install dependencies
-        run: |
-          npm install
+        run: npm ci
 
       - name: Check linting
         run: npm run lint

--- a/docs/main/getting_started/styling_pay_theory_fields.mdx
+++ b/docs/main/getting_started/styling_pay_theory_fields.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 sidebar_label: 'Styling and Managing States'
-title: "Styling and Managing States"
+title: 'Styling and Managing States'
 hide_table_of_contents: true
 ---
 
@@ -21,50 +21,141 @@ import Admonition from '@theme/Admonition';
 <TabItem value="javascript">
 
 # Styling and Managing States
+
 This guide will walk you through the basics of styling your Pay Theory Fields and state management. You will learn how to style the text inputs and radio buttons using CSS and how to use the stateObserver.
 
 ## Styling the Pay Theory fields
-To style the Pay Theory fields you can pass in a custom style object to the create function in our SDK. This allows you to style the text inside the inputs as well as the style of the radio buttons for the ACH account type.
+
+To style the Pay Theory fields you can pass in a custom style object to the create function in our SDK. The style object accepts a fixed set of keys for each surface — text inputs (across `default`, `success`, and `error` states), the ACH account-type radio buttons, the hosted checkout button, and the placeholder visibility flag. Any property not listed in the tables below is silently ignored.
 
 ```jsx title="paytheory.js"
 const STYLES = {
   default: {
     color: 'black',
-    fontSize: '14px'
+    fontSize: '14px',
+    fontFamily: 'Helvetica, Arial, sans-serif',
+    padding: '10px',
+    border: '1px solid #ccc',
+    borderRadius: '4px',
+    backgroundColor: '#ffffff',
   },
   success: {
     color: '#5cb85c',
-    fontSize: '14px'
+    borderColor: '#5cb85c',
   },
   error: {
     color: '#d9534f',
-    fontSize: '14px'
+    borderColor: '#d9534f',
   },
   radio: {
     width: 18,
-    fill: "blue",
-    stroke: "grey",
-    text: {
-    fontSize: "18px",
-    color: "grey"
-    }
+    fill: 'blue',
+    stroke: 'grey',
+    textFontSize: '14px',
+    textColor: 'grey',
+    textFontFamily: 'Helvetica, Arial, sans-serif',
   },
-hidePlaceholder: false
-}
+  button: {
+    color: 'PURPLE',
+    callToAction: 'PAY',
+    pill: false,
+    height: 48,
+  },
+  hidePlaceholder: false,
+};
 ```
 
-| KEY               | TYPE     | DESCRIPTION                                                            |
-|-------------------|----------|------------------------------------------------------------------------|
-| default           | object   | The way a text field looks when it is not in state success or error.   |
-| success           | object   | The way a text field looks when it is valid. Only applies to fields that go through validation.   |
-| error             | object   | The way a text field looks when it is invalid. Only applies to fields that go through validation.   |
-| radio             | object   | The way radio buttons look for the ACH account type <ul><li>`width: (int)` The width in pixels of the radio buttons</li><li>`fill: (string)` The color of the radio buttons</li><li>`stroke: (string)` The color of the radio buttons border</li><li>`text: (object)` This style object will be used to style the labels for the radio buttons</li></ul> |
-| hidePlaceholder   | boolean  | This allows you to hide the placeholder text in the input fields.   |
+### Top-level keys
 
-The way radio buttons look for the ACH account type <ul><li>`width: (int)` The width in pixels of the radio buttons</li><li>`fill: (string)` The color of the radio buttons</li><li>`stroke: (string)` The color of the radio buttons border</li><li>`text: (object)` This style object will be used to style the labels for the radio buttons</li></ul>
-***
+| Key               | type    | description                                                                                                                                    |
+| ----------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default`         | object  | Styling applied to text inputs when not in `success` or `error` state. Accepts the [field state properties](#field-state-properties).          |
+| `success`         | object  | Styling applied to text inputs that pass validation. Merged on top of `default` — any property not set here falls back to its `default` value. |
+| `error`           | object  | Styling applied to text inputs that fail validation. Merged on top of `default` — same fallback behavior as `success`.                         |
+| `radio`           | object  | Styling for the ACH account-type radio buttons. See [Radio object](#radio-object).                                                             |
+| `button`          | object  | Styling for the hosted checkout button. See [Button object](#button-object).                                                                   |
+| `hidePlaceholder` | boolean | When `true`, the placeholder text in the input fields is hidden. Defaults to `false`.                                                          |
+
+:::info success and error inherit from default
+Properties set in `default` automatically apply to `success` and `error` too — you only need to override the keys that actually change between states (commonly `color` and `borderColor`).
+:::
+
+### Field state properties
+
+`default`, `success`, and `error` each accept the same 18 properties. All values are CSS strings; any other key is ignored.
+
+| Key                | type   | description                                                                                                                                                              |
+| ------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `color`            | string | Text color. Accepts hex (`#fff`, `#ffffff`), `rgb()` / `rgba()`, `hsl()` / `hsla()`, named colors, CSS variables (`var(--x)`), `transparent`, `inherit`.                 |
+| `fontSize`         | string | Font size. Numeric value with a unit (`px`, `em`, `rem`, `%`, `vh`, `vw`, `pt`, `pc`, `in`, `cm`, `mm`, `ex`, `ch`, `vmin`, `vmax`), or `calc(...)`, `var(...)`, `auto`. |
+| `fontFamily`       | string | Font family stack. Capped at 100 characters.                                                                                                                             |
+| `lineHeight`       | string | CSS `line-height` value.                                                                                                                                                 |
+| `padding`          | string | CSS `padding` shorthand. Same unit rules as `fontSize`.                                                                                                                  |
+| `margin`           | string | CSS `margin` shorthand. Same unit rules as `fontSize`.                                                                                                                   |
+| `textAlign`        | string | CSS `text-align` value (`left`, `right`, `center`, `justify`, `start`, `end`).                                                                                           |
+| `border`           | string | CSS `border` shorthand (e.g. `'1px solid #ccc'`).                                                                                                                        |
+| `borderColor`      | string | Border color only. Same value rules as `color`.                                                                                                                          |
+| `borderRadius`     | string | CSS `border-radius` value.                                                                                                                                               |
+| `backgroundColor`  | string | Background color. Same value rules as `color`.                                                                                                                           |
+| `boxShadow`        | string | CSS `box-shadow` value.                                                                                                                                                  |
+| `outline`          | string | CSS `outline` shorthand.                                                                                                                                                 |
+| `width`            | string | CSS `width`. Same unit rules as `fontSize`.                                                                                                                              |
+| `height`           | string | CSS `height`. Same unit rules as `fontSize`.                                                                                                                             |
+| `transition`       | string | CSS `transition` shorthand.                                                                                                                                              |
+| `opacity`          | string | CSS `opacity` (`'0'`–`'1'`).                                                                                                                                             |
+| `webkitAppearance` | string | CSS `-webkit-appearance` value.                                                                                                                                          |
+
+### Radio object
+
+Styles for the ACH account-type radio buttons. Both the flat properties and the legacy nested `text` object are supported; if both forms are set, the nested values take precedence.
+
+| Key              | type          | description                                                                                |
+| ---------------- | ------------- | ------------------------------------------------------------------------------------------ |
+| `width`          | int \| string | Width of the radio button. Bare numbers are interpreted as pixels.                         |
+| `fill`           | string        | Fill color of the selected indicator.                                                      |
+| `stroke`         | string        | Color of the radio outline.                                                                |
+| `textFontSize`   | string        | Font size for the radio label.                                                             |
+| `textColor`      | string        | Color for the radio label.                                                                 |
+| `textFontFamily` | string        | Font family for the radio label.                                                           |
+| `text`           | object        | Backwards-compatible nested form. Accepts `fontSize`, `color`, `fontFamily`, `fontWeight`. |
+
+### Button object
+
+Styles for the hosted checkout button. The button accepts a **config** form (preset color and call-to-action — the common case) or a **processed** form where you set the resolved CSS properties directly.
+
+**Config form**
+
+| Key            | type                                              | description                                                                     |
+| -------------- | ------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `color`        | `'PURPLE'` \| `'WHITE'` \| `'BLACK'` \| `'GREY'`  | Preset color theme. Matching is case-insensitive. Defaults to `'PURPLE'`.       |
+| `callToAction` | `'PAY'` \| `'CHECKOUT'` \| `'DONATE'` \| `'BOOK'` | Sets the button copy (e.g. `'PAY'` → "Pay with"). Matching is case-insensitive. |
+| `pill`         | boolean                                           | When `true`, gives the button a fully rounded (pill) shape.                     |
+| `height`       | int \| string                                     | Button height. Numbers are interpreted as pixels.                               |
+
+**Processed form**
+
+| Key               | type   | description                                                       |
+| ----------------- | ------ | ----------------------------------------------------------------- |
+| `backgroundColor` | string | Button background color. Default: `#9139D2`.                      |
+| `borderRadius`    | string | Button corner radius. Default: `4px` (`100px` when `pill: true`). |
+| `fontColor`       | string | Button text color. Default: `#FFFFFF`.                            |
+| `height`          | string | Button height. Default: `48px`.                                   |
+| `border`          | string | CSS `border` shorthand (e.g. `'0.5px solid #C9C4CA'`).            |
+| `altText`         | string | Accessible label / button copy.                                   |
+
+**Defaults applied by preset `color`**
+
+| `color`  | background | text color | border                |
+| -------- | ---------- | ---------- | --------------------- |
+| `PURPLE` | `#9139D2`  | `#FFFFFF`  | none                  |
+| `BLACK`  | `#000000`  | `#FFFFFF`  | none                  |
+| `WHITE`  | `#FFFFFF`  | `#000000`  | `0.5px solid #C9C4CA` |
+| `GREY`   | `#F7F7F4`  | `#000000`  | none                  |
+
+---
 
 ## Additional styling
+
 To style the input parent div, provide your own CSS for the Pay Theory containers you create. This is best used to style the height, width, and border of the container.
 
 :::danger Warning
@@ -82,44 +173,51 @@ Individual pay-theory-credit-card-number containers should be at least 340px wid
 }
 ```
 
-***
+---
 
 ## Using the stateObserver
+
 A stateObserver lets you keep an eye on changes to the state of hosted fields and react to them. It offers a mechanism to keep a look on things like field focus, if a field is empty or if there are any validation errors with the field. Each time the state of a text input changes, the stateObserver callback method is called.
 
 ```jsx title="src/paytheory.js"
-const stateHandler = (state) => {
-  const cardState = state['card-number']
-  const cardField = document.getElementById("pay-theory-credit-card-number")
-  if(cardState.isDirty) {
-    cardField.classList.add("dirty")
+const stateHandler = state => {
+  const cardState = state['card-number'];
+  const cardField = document.getElementById('pay-theory-credit-card-number');
+  if (cardState.isDirty) {
+    cardField.classList.add('dirty');
   } else {
-    cardField.classList.remove("dirty")
+    cardField.classList.remove('dirty');
   }
-  if(cardState.isFocused) {
-    cardField.classList.add("focused")
+  if (cardState.isFocused) {
+    cardField.classList.add('focused');
   } else {
-    cardField.classList.remove("focused")
+    cardField.classList.remove('focused');
   }
-  if(cardState.errorMessages && cardState.errorMessages.length > 0) {
-    cardField.classList.add("error")
+  if (cardState.errorMessages && cardState.errorMessages.length > 0) {
+    cardField.classList.add('error');
   } else {
-    cardField.classList.remove("error")
+    cardField.classList.remove('error');
   }
-}
+};
 
-window.paytheory.stateObserver(stateHandler)
+window.paytheory.stateObserver(stateHandler);
 ```
+
 :::info Additional stateObserver functionality
 For more details on stateObserver functionality
 
-<a href= "../../sdk/javascript/EVENT_LISTENERS#stateobserver" class="button button--primary button--md">View stateObserver</a>
+<a
+  href="../../sdk/javascript/EVENT_LISTENERS#stateobserver"
+  class="button button--primary button--md">
+  View stateObserver
+</a>
 :::
-***
+
+---
 
 ## Next steps
-Once your Pay Theory fields are stylized you will need to make sure Error handling is set up. Additionally you can further customize your Pay Theory fields by adding [Cash](../online_payments/cash_payments.mdx) and or [ACH](../online_payments/ach_payments) functionality.
 
+Once your Pay Theory fields are stylized you will need to make sure Error handling is set up. Additionally you can further customize your Pay Theory fields by adding [Cash](../online_payments/cash_payments.mdx) and or [ACH](../online_payments/ach_payments) functionality.
 
 </TabItem>
   <TabItem value="apple">

--- a/docs/sdk/javascript/hosted_fields.md
+++ b/docs/sdk/javascript/hosted_fields.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 sidebar_label: 'Hosted Fields'
-title: "Hosted Fields"
+title: 'Hosted Fields'
 ---
 
 # Hosted Fields
@@ -20,11 +20,11 @@ These fields are used to collect the required info from the user for a valid car
 
 ```html
 <form>
-...
-<div id="pay-theory-credit-card-number"></div>
-<div id="pay-theory-credit-card-exp"></div>
-<div id="pay-theory-credit-card-cvv"></div>
-...
+  ...
+  <div id="pay-theory-credit-card-number"></div>
+  <div id="pay-theory-credit-card-exp"></div>
+  <div id="pay-theory-credit-card-cvv"></div>
+  ...
 </form>
 ```
 
@@ -34,9 +34,9 @@ These fields are used to collect the required info from the user for a valid car
 
 ```html
 <form>
-...
-<div id="pay-theory-credit-card"></div>
-...
+  ...
+  <div id="pay-theory-credit-card"></div>
+  ...
 </form>
 ```
 
@@ -110,7 +110,6 @@ This button will open a hosted checkout page that will allow the user to select 
 <div id="pay-theory-checkout-button"></div>
 ```
 
-
 ## QR Code Field
 
 This div is used to mount an iframe that will include a QR Code.
@@ -120,35 +119,25 @@ This QR Code will open a hosted checkout page that will allow the user to select
 <div id="pay-theory-checkout-qr"></div>
 ```
 
-[//]: # (## Card Present Field)
-
-[//]: # ()
-[//]: # (This div is used to mount an iframe that will allow the SDK to communicate to Pay Theory.)
-
-[//]: # ()
-[//]: # (This div is required for card present to work but is not shown and is set to `display: none` by default.)
-
-[//]: # ()
-[//]: # (```html)
-
-[//]: # (<form>)
-
-[//]: # (...)
-
-[//]: # (<div id="pay-theory-card-present"></div>)
-
-[//]: # (...)
-
-[//]: # (</form>)
-
-[//]: # (```)
-
+[//]: # '## Card Present Field'
+[//]: #
+[//]: # 'This div is used to mount an iframe that will allow the SDK to communicate to Pay Theory.'
+[//]: #
+[//]: # 'This div is required for card present to work but is not shown and is set to `display: none` by default.'
+[//]: #
+[//]: # '```html'
+[//]: # '<form>'
+[//]: # '...'
+[//]: # '<div id="pay-theory-card-present"></div>'
+[//]: # '...'
+[//]: # '</form>'
+[//]: # '```'
 
 ## Styling Hosted Fields
 
 To style the input parent div simply provide your own CSS for the pay theory containers you create. This is best used to style the height, width, and border of the container.
 
-*Individual pay-theory-credit-card-number containers should be at least 340px wide, pay-theory-credit-card combined input should be 400px*
+_Individual pay-theory-credit-card-number containers should be at least 340px wide, pay-theory-credit-card combined input should be 400px_
 
 ```css
 #pay-theory-credit-card-number,
@@ -161,61 +150,135 @@ To style the input parent div simply provide your own CSS for the pay theory con
 }
 ```
 
-## Styles Object
+### Styles Object
 
-To style the input fields you can pass in a custom style object to the create function in our SDK. This allows you to style the text inside the inputs as well as the style of the radio buttons for the ACH account type
+To style the input fields you can pass in a custom style object to the create function in our SDK. The style object accepts a fixed set of keys — any property not listed in the tables below is silently ignored.
 
 ```javascript
 const STYLES = {
   default: {
     color: 'black',
-    fontSize: '14px'
+    fontSize: '14px',
+    fontFamily: 'Helvetica, Arial, sans-serif',
+    padding: '10px',
+    border: '1px solid #ccc',
+    borderRadius: '4px',
+    backgroundColor: '#ffffff',
   },
   success: {
     color: '#5cb85c',
-    fontSize: '14px'
+    borderColor: '#5cb85c',
   },
   error: {
     color: '#d9534f',
-    fontSize: '14px'
+    borderColor: '#d9534f',
   },
   radio: {
     width: 18,
-    fill: "blue",
-    stroke: "grey",
-    text: {
-      fontSize: "18px",
-      color: "grey"
-    }
+    fill: 'blue',
+    stroke: 'grey',
+    textFontSize: '14px',
+    textColor: 'grey',
+    textFontFamily: 'Helvetica, Arial, sans-serif',
   },
-  hidePlaceholder: false
-}
+  button: {
+    color: 'PURPLE',
+    callToAction: 'PAY',
+    pill: false,
+    height: 48,
+  },
+  hidePlaceholder: false,
+};
 ```
 
-|Key                | type                          |       description                     |
-|-------------------|-------------------------------|---------------------------------------|
-|default            | CSS Style Object              |The way a text field look when it is not in state success or error.|
-|success            | CSS Style Object              |The way a text field look when it is valid. Only applies to fields that go through validation.|
-|error              | CSS Style Object              |The way a text field look when it is invalid. Only applies to fields that go through validation.|
-|radio              | [Radio Object](#radio-object) |The way radio buttons look for the ACH account type|
-|hidePlaceholder    | Boolean                       |that allows you to hide the placeholder text in the input fields|
+| Key               | type                                      | description                                                                                                                                    |
+| ----------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default`         | [Field Style Object](#field-style-object) | Styling applied to text inputs when not in `success` or `error` state.                                                                         |
+| `success`         | [Field Style Object](#field-style-object) | Styling applied to text inputs that pass validation. Merged on top of `default` — any property not set here falls back to its `default` value. |
+| `error`           | [Field Style Object](#field-style-object) | Styling applied to text inputs that fail validation. Merged on top of `default` — same fallback behavior as `success`.                         |
+| `radio`           | [Radio Object](#radio-object)             | Styling for the ACH account-type radio buttons.                                                                                                |
+| `button`          | [Button Object](#button-object)           | Styling for the hosted checkout button.                                                                                                        |
+| `hidePlaceholder` | Boolean                                   | When `true`, the placeholder text in the input fields is hidden. Defaults to `false`.                                                          |
 
-## Radio Object
+### Field Style Object
 
-This style object will be used to style the labels for the radio buttons. It contains the following keys:
+The `default`, `success`, and `error` keys each accept the same 18 properties. All values are CSS strings.
 
-|Key                | type                        |       description                     |
-|-------------------|-----------------------------|---------------------------------------|
-|width              | Int                         |The width in pixels of the radio buttons|
-|fill               | String                      |The color of the radio buttons|
-|stroke             | String                      |The color of the radio buttons border|
-|text               | [Text Object](#text-object) |This style object will be used to style the labels for the radio buttons|
+| Key                | type   | description                                                                                                                                                   |
+| ------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `color`            | String | Text color. Accepts hex, `rgb()` / `rgba()`, `hsl()` / `hsla()`, named colors, CSS variables (`var(--x)`), `transparent`, `inherit`.                          |
+| `fontSize`         | String | Font size. Numeric + unit (`px`, `em`, `rem`, `%`, `vh`, `vw`, `pt`, `pc`, `in`, `cm`, `mm`, `ex`, `ch`, `vmin`, `vmax`), or `calc(...)`, `var(...)`, `auto`. |
+| `fontFamily`       | String | Font family stack. Capped at 100 characters.                                                                                                                  |
+| `lineHeight`       | String | CSS `line-height` value.                                                                                                                                      |
+| `padding`          | String | CSS `padding` shorthand. Same unit rules as `fontSize`.                                                                                                       |
+| `margin`           | String | CSS `margin` shorthand. Same unit rules as `fontSize`.                                                                                                        |
+| `textAlign`        | String | CSS `text-align` value (`left`, `right`, `center`, `justify`, `start`, `end`).                                                                                |
+| `border`           | String | CSS `border` shorthand (e.g. `'1px solid #ccc'`).                                                                                                             |
+| `borderColor`      | String | Border color only. Same value rules as `color`.                                                                                                               |
+| `borderRadius`     | String | CSS `border-radius` value.                                                                                                                                    |
+| `backgroundColor`  | String | Background color. Same value rules as `color`.                                                                                                                |
+| `boxShadow`        | String | CSS `box-shadow` value.                                                                                                                                       |
+| `outline`          | String | CSS `outline` shorthand.                                                                                                                                      |
+| `width`            | String | CSS `width`. Same unit rules as `fontSize`.                                                                                                                   |
+| `height`           | String | CSS `height`. Same unit rules as `fontSize`.                                                                                                                  |
+| `transition`       | String | CSS `transition` shorthand.                                                                                                                                   |
+| `opacity`          | String | CSS `opacity` (`'0'`–`'1'`).                                                                                                                                  |
+| `webkitAppearance` | String | CSS `-webkit-appearance` value.                                                                                                                               |
 
-## Text Object
+### Radio Object
 
-This style object will be used to style the labels for the radio buttons. It contains the following keys:
+Styles for the ACH account-type radio buttons. Both the flat properties and the legacy nested `text` object are supported; if both forms are set, the nested values take precedence.
 
-|Key                |type         |       description                     |
-|-------------------|-------------|---------------------------------------|
-|fontSize           |String       |The font size of the radio button labels|
-|color              |String       |The color of the radio button labels|
+| Key              | type                        | description                                                        |
+| ---------------- | --------------------------- | ------------------------------------------------------------------ |
+| `width`          | Int \| String               | Width of the radio button. Bare numbers are interpreted as pixels. |
+| `fill`           | String                      | Fill color of the selected indicator.                              |
+| `stroke`         | String                      | Color of the radio outline.                                        |
+| `textFontSize`   | String                      | Font size for the radio label.                                     |
+| `textColor`      | String                      | Color for the radio label.                                         |
+| `textFontFamily` | String                      | Font family for the radio label.                                   |
+| `text`           | [Text Object](#text-object) | Backwards-compatible nested form for label styling.                |
+
+### Text Object
+
+Backwards-compatible nested form for styling the radio button labels.
+
+| Key          | type   | description                             |
+| ------------ | ------ | --------------------------------------- |
+| `fontSize`   | String | Font size of the radio button labels.   |
+| `color`      | String | Color of the radio button labels.       |
+| `fontFamily` | String | Font family of the radio button labels. |
+| `fontWeight` | String | Font weight of the radio button labels. |
+
+### Button Object
+
+Styles for the hosted checkout button. The button accepts a **config** form (preset color and call-to-action — the common case) or a **processed** form where you set the resolved CSS properties directly.
+
+**Config form**
+
+| Key            | type                                              | description                                                                     |
+| -------------- | ------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `color`        | `'PURPLE'` \| `'WHITE'` \| `'BLACK'` \| `'GREY'`  | Preset color theme. Matching is case-insensitive. Defaults to `'PURPLE'`.       |
+| `callToAction` | `'PAY'` \| `'CHECKOUT'` \| `'DONATE'` \| `'BOOK'` | Sets the button copy (e.g. `'PAY'` → "Pay with"). Matching is case-insensitive. |
+| `pill`         | Boolean                                           | When `true`, gives the button a fully rounded (pill) shape.                     |
+| `height`       | Int \| String                                     | Button height. Numbers are interpreted as pixels.                               |
+
+**Processed form**
+
+| Key               | type   | description                                                       |
+| ----------------- | ------ | ----------------------------------------------------------------- |
+| `backgroundColor` | String | Button background color. Default: `#9139D2`.                      |
+| `borderRadius`    | String | Button corner radius. Default: `4px` (`100px` when `pill: true`). |
+| `fontColor`       | String | Button text color. Default: `#FFFFFF`.                            |
+| `height`          | String | Button height. Default: `48px`.                                   |
+| `border`          | String | CSS `border` shorthand (e.g. `'0.5px solid #C9C4CA'`).            |
+| `altText`         | String | Accessible label / button copy.                                   |
+
+**Defaults applied by preset `color`**
+
+| `color`  | background | text color | border                |
+| -------- | ---------- | ---------- | --------------------- |
+| `PURPLE` | `#9139D2`  | `#FFFFFF`  | none                  |
+| `BLACK`  | `#000000`  | `#FFFFFF`  | none                  |
+| `WHITE`  | `#FFFFFF`  | `#000000`  | `0.5px solid #C9C4CA` |
+| `GREY`   | `#F7F7F4`  | `#000000`  | none                  |

--- a/versioned_docs/version-lab/main/getting_started/styling_pay_theory_fields.mdx
+++ b/versioned_docs/version-lab/main/getting_started/styling_pay_theory_fields.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 sidebar_label: 'Styling and Managing States'
-title: "Styling and Managing States"
+title: 'Styling and Managing States'
 hide_table_of_contents: true
 ---
 
@@ -21,50 +21,141 @@ import Admonition from '@theme/Admonition';
 <TabItem value="javascript">
 
 # Styling and Managing States
+
 This guide will walk you through the basics of styling your Pay Theory Fields and state management. You will learn how to style the text inputs and radio buttons using CSS and how to use the stateObserver.
 
 ## Styling the Pay Theory fields
-To style the Pay Theory fields you can pass in a custom style object to the create function in our SDK. This allows you to style the text inside the inputs as well as the style of the radio buttons for the ACH account type.
+
+To style the Pay Theory fields you can pass in a custom style object to the create function in our SDK. The style object accepts a fixed set of keys for each surface — text inputs (across `default`, `success`, and `error` states), the ACH account-type radio buttons, the hosted checkout button, and the placeholder visibility flag. Any property not listed in the tables below is silently ignored.
 
 ```jsx title="paytheory.js"
 const STYLES = {
   default: {
     color: 'black',
-    fontSize: '14px'
+    fontSize: '14px',
+    fontFamily: 'Helvetica, Arial, sans-serif',
+    padding: '10px',
+    border: '1px solid #ccc',
+    borderRadius: '4px',
+    backgroundColor: '#ffffff',
   },
   success: {
     color: '#5cb85c',
-    fontSize: '14px'
+    borderColor: '#5cb85c',
   },
   error: {
     color: '#d9534f',
-    fontSize: '14px'
+    borderColor: '#d9534f',
   },
   radio: {
     width: 18,
-    fill: "blue",
-    stroke: "grey",
-    text: {
-    fontSize: "18px",
-    color: "grey"
-    }
+    fill: 'blue',
+    stroke: 'grey',
+    textFontSize: '14px',
+    textColor: 'grey',
+    textFontFamily: 'Helvetica, Arial, sans-serif',
   },
-hidePlaceholder: false
-}
+  button: {
+    color: 'PURPLE',
+    callToAction: 'PAY',
+    pill: false,
+    height: 48,
+  },
+  hidePlaceholder: false,
+};
 ```
 
-| KEY               | TYPE     | DESCRIPTION                                                            |
-|-------------------|----------|------------------------------------------------------------------------|
-| default           | object   | The way a text field looks when it is not in state success or error.   |
-| success           | object   | The way a text field looks when it is valid. Only applies to fields that go through validation.   |
-| error             | object   | The way a text field looks when it is invalid. Only applies to fields that go through validation.   |
-| radio             | object   | The way radio buttons look for the ACH account type <ul><li>`width: (int)` The width in pixels of the radio buttons</li><li>`fill: (string)` The color of the radio buttons</li><li>`stroke: (string)` The color of the radio buttons border</li><li>`text: (object)` This style object will be used to style the labels for the radio buttons</li></ul> |
-| hidePlaceholder   | boolean  | This allows you to hide the placeholder text in the input fields.   |
+### Top-level keys
 
-The way radio buttons look for the ACH account type <ul><li>`width: (int)` The width in pixels of the radio buttons</li><li>`fill: (string)` The color of the radio buttons</li><li>`stroke: (string)` The color of the radio buttons border</li><li>`text: (object)` This style object will be used to style the labels for the radio buttons</li></ul>
-***
+| Key               | type    | description                                                                                                                                    |
+| ----------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default`         | object  | Styling applied to text inputs when not in `success` or `error` state. Accepts the [field state properties](#field-state-properties).          |
+| `success`         | object  | Styling applied to text inputs that pass validation. Merged on top of `default` — any property not set here falls back to its `default` value. |
+| `error`           | object  | Styling applied to text inputs that fail validation. Merged on top of `default` — same fallback behavior as `success`.                         |
+| `radio`           | object  | Styling for the ACH account-type radio buttons. See [Radio object](#radio-object).                                                             |
+| `button`          | object  | Styling for the hosted checkout button. See [Button object](#button-object).                                                                   |
+| `hidePlaceholder` | boolean | When `true`, the placeholder text in the input fields is hidden. Defaults to `false`.                                                          |
+
+:::info success and error inherit from default
+Properties set in `default` automatically apply to `success` and `error` too — you only need to override the keys that actually change between states (commonly `color` and `borderColor`).
+:::
+
+### Field state properties
+
+`default`, `success`, and `error` each accept the same 18 properties. All values are CSS strings; any other key is ignored.
+
+| Key                | type   | description                                                                                                                                                              |
+| ------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `color`            | string | Text color. Accepts hex (`#fff`, `#ffffff`), `rgb()` / `rgba()`, `hsl()` / `hsla()`, named colors, CSS variables (`var(--x)`), `transparent`, `inherit`.                 |
+| `fontSize`         | string | Font size. Numeric value with a unit (`px`, `em`, `rem`, `%`, `vh`, `vw`, `pt`, `pc`, `in`, `cm`, `mm`, `ex`, `ch`, `vmin`, `vmax`), or `calc(...)`, `var(...)`, `auto`. |
+| `fontFamily`       | string | Font family stack. Capped at 100 characters.                                                                                                                             |
+| `lineHeight`       | string | CSS `line-height` value.                                                                                                                                                 |
+| `padding`          | string | CSS `padding` shorthand. Same unit rules as `fontSize`.                                                                                                                  |
+| `margin`           | string | CSS `margin` shorthand. Same unit rules as `fontSize`.                                                                                                                   |
+| `textAlign`        | string | CSS `text-align` value (`left`, `right`, `center`, `justify`, `start`, `end`).                                                                                           |
+| `border`           | string | CSS `border` shorthand (e.g. `'1px solid #ccc'`).                                                                                                                        |
+| `borderColor`      | string | Border color only. Same value rules as `color`.                                                                                                                          |
+| `borderRadius`     | string | CSS `border-radius` value.                                                                                                                                               |
+| `backgroundColor`  | string | Background color. Same value rules as `color`.                                                                                                                           |
+| `boxShadow`        | string | CSS `box-shadow` value.                                                                                                                                                  |
+| `outline`          | string | CSS `outline` shorthand.                                                                                                                                                 |
+| `width`            | string | CSS `width`. Same unit rules as `fontSize`.                                                                                                                              |
+| `height`           | string | CSS `height`. Same unit rules as `fontSize`.                                                                                                                             |
+| `transition`       | string | CSS `transition` shorthand.                                                                                                                                              |
+| `opacity`          | string | CSS `opacity` (`'0'`–`'1'`).                                                                                                                                             |
+| `webkitAppearance` | string | CSS `-webkit-appearance` value.                                                                                                                                          |
+
+### Radio object
+
+Styles for the ACH account-type radio buttons. Both the flat properties and the legacy nested `text` object are supported; if both forms are set, the nested values take precedence.
+
+| Key              | type          | description                                                                                |
+| ---------------- | ------------- | ------------------------------------------------------------------------------------------ |
+| `width`          | int \| string | Width of the radio button. Bare numbers are interpreted as pixels.                         |
+| `fill`           | string        | Fill color of the selected indicator.                                                      |
+| `stroke`         | string        | Color of the radio outline.                                                                |
+| `textFontSize`   | string        | Font size for the radio label.                                                             |
+| `textColor`      | string        | Color for the radio label.                                                                 |
+| `textFontFamily` | string        | Font family for the radio label.                                                           |
+| `text`           | object        | Backwards-compatible nested form. Accepts `fontSize`, `color`, `fontFamily`, `fontWeight`. |
+
+### Button object
+
+Styles for the hosted checkout button. The button accepts a **config** form (preset color and call-to-action — the common case) or a **processed** form where you set the resolved CSS properties directly.
+
+**Config form**
+
+| Key            | type                                              | description                                                                     |
+| -------------- | ------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `color`        | `'PURPLE'` \| `'WHITE'` \| `'BLACK'` \| `'GREY'`  | Preset color theme. Matching is case-insensitive. Defaults to `'PURPLE'`.       |
+| `callToAction` | `'PAY'` \| `'CHECKOUT'` \| `'DONATE'` \| `'BOOK'` | Sets the button copy (e.g. `'PAY'` → "Pay with"). Matching is case-insensitive. |
+| `pill`         | boolean                                           | When `true`, gives the button a fully rounded (pill) shape.                     |
+| `height`       | int \| string                                     | Button height. Numbers are interpreted as pixels.                               |
+
+**Processed form**
+
+| Key               | type   | description                                                       |
+| ----------------- | ------ | ----------------------------------------------------------------- |
+| `backgroundColor` | string | Button background color. Default: `#9139D2`.                      |
+| `borderRadius`    | string | Button corner radius. Default: `4px` (`100px` when `pill: true`). |
+| `fontColor`       | string | Button text color. Default: `#FFFFFF`.                            |
+| `height`          | string | Button height. Default: `48px`.                                   |
+| `border`          | string | CSS `border` shorthand (e.g. `'0.5px solid #C9C4CA'`).            |
+| `altText`         | string | Accessible label / button copy.                                   |
+
+**Defaults applied by preset `color`**
+
+| `color`  | background | text color | border                |
+| -------- | ---------- | ---------- | --------------------- |
+| `PURPLE` | `#9139D2`  | `#FFFFFF`  | none                  |
+| `BLACK`  | `#000000`  | `#FFFFFF`  | none                  |
+| `WHITE`  | `#FFFFFF`  | `#000000`  | `0.5px solid #C9C4CA` |
+| `GREY`   | `#F7F7F4`  | `#000000`  | none                  |
+
+---
 
 ## Additional styling
+
 To style the input parent div, provide your own CSS for the Pay Theory containers you create. This is best used to style the height, width, and border of the container.
 
 :::danger Warning
@@ -82,44 +173,51 @@ Individual pay-theory-credit-card-number containers should be at least 340px wid
 }
 ```
 
-***
+---
 
 ## Using the stateObserver
+
 A stateObserver lets you keep an eye on changes to the state of hosted fields and react to them. It offers a mechanism to keep a look on things like field focus, if a field is empty or if there are any validation errors with the field. Each time the state of a text input changes, the stateObserver callback method is called.
 
 ```jsx title="src/paytheory.js"
-const stateHandler = (state) => {
-  const cardState = state['card-number']
-  const cardField = document.getElementById("pay-theory-credit-card-number")
-  if(cardState.isDirty) {
-    cardField.classList.add("dirty")
+const stateHandler = state => {
+  const cardState = state['card-number'];
+  const cardField = document.getElementById('pay-theory-credit-card-number');
+  if (cardState.isDirty) {
+    cardField.classList.add('dirty');
   } else {
-    cardField.classList.remove("dirty")
+    cardField.classList.remove('dirty');
   }
-  if(cardState.isFocused) {
-    cardField.classList.add("focused")
+  if (cardState.isFocused) {
+    cardField.classList.add('focused');
   } else {
-    cardField.classList.remove("focused")
+    cardField.classList.remove('focused');
   }
-  if(cardState.errorMessages && cardState.errorMessages.length > 0) {
-    cardField.classList.add("error")
+  if (cardState.errorMessages && cardState.errorMessages.length > 0) {
+    cardField.classList.add('error');
   } else {
-    cardField.classList.remove("error")
+    cardField.classList.remove('error');
   }
-}
+};
 
-window.paytheory.stateObserver(stateHandler)
+window.paytheory.stateObserver(stateHandler);
 ```
+
 :::info Additional stateObserver functionality
 For more details on stateObserver functionality
 
-<a href= "../../sdk/javascript/EVENT_LISTENERS#stateobserver" class="button button--primary button--md">View stateObserver</a>
+<a
+  href="../../sdk/javascript/EVENT_LISTENERS#stateobserver"
+  class="button button--primary button--md">
+  View stateObserver
+</a>
 :::
-***
+
+---
 
 ## Next steps
-Once your Pay Theory fields are stylized you will need to make sure Error handling is set up. Additionally you can further customize your Pay Theory fields by adding [Cash](../online_payments/cash_payments.mdx) and or [ACH](../online_payments/ach_payments) functionality.
 
+Once your Pay Theory fields are stylized you will need to make sure Error handling is set up. Additionally you can further customize your Pay Theory fields by adding [Cash](../online_payments/cash_payments.mdx) and or [ACH](../online_payments/ach_payments) functionality.
 
 </TabItem>
   <TabItem value="apple">

--- a/versioned_docs/version-lab/sdk/javascript/hosted_fields.md
+++ b/versioned_docs/version-lab/sdk/javascript/hosted_fields.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 sidebar_label: 'Hosted Fields'
-title: "Hosted Fields"
+title: 'Hosted Fields'
 ---
 
 # Hosted Fields
@@ -20,11 +20,11 @@ These fields are used to collect the required info from the user for a valid car
 
 ```html
 <form>
-...
-<div id="pay-theory-credit-card-number"></div>
-<div id="pay-theory-credit-card-exp"></div>
-<div id="pay-theory-credit-card-cvv"></div>
-...
+  ...
+  <div id="pay-theory-credit-card-number"></div>
+  <div id="pay-theory-credit-card-exp"></div>
+  <div id="pay-theory-credit-card-cvv"></div>
+  ...
 </form>
 ```
 
@@ -34,9 +34,9 @@ These fields are used to collect the required info from the user for a valid car
 
 ```html
 <form>
-...
-<div id="pay-theory-credit-card"></div>
-...
+  ...
+  <div id="pay-theory-credit-card"></div>
+  ...
 </form>
 ```
 
@@ -110,7 +110,6 @@ This button will open a hosted checkout page that will allow the user to select 
 <div id="pay-theory-checkout-button"></div>
 ```
 
-
 ## QR Code Field
 
 This div is used to mount an iframe that will include a QR Code.
@@ -120,35 +119,25 @@ This QR Code will open a hosted checkout page that will allow the user to select
 <div id="pay-theory-checkout-qr"></div>
 ```
 
-[//]: # (## Card Present Field)
-
-[//]: # ()
-[//]: # (This div is used to mount an iframe that will allow the SDK to communicate to Pay Theory.)
-
-[//]: # ()
-[//]: # (This div is required for card present to work but is not shown and is set to `display: none` by default.)
-
-[//]: # ()
-[//]: # (```html)
-
-[//]: # (<form>)
-
-[//]: # (...)
-
-[//]: # (<div id="pay-theory-card-present"></div>)
-
-[//]: # (...)
-
-[//]: # (</form>)
-
-[//]: # (```)
-
+[//]: # '## Card Present Field'
+[//]: #
+[//]: # 'This div is used to mount an iframe that will allow the SDK to communicate to Pay Theory.'
+[//]: #
+[//]: # 'This div is required for card present to work but is not shown and is set to `display: none` by default.'
+[//]: #
+[//]: # '```html'
+[//]: # '<form>'
+[//]: # '...'
+[//]: # '<div id="pay-theory-card-present"></div>'
+[//]: # '...'
+[//]: # '</form>'
+[//]: # '```'
 
 ## Styling Hosted Fields
 
 To style the input parent div simply provide your own CSS for the pay theory containers you create. This is best used to style the height, width, and border of the container.
 
-*Individual pay-theory-credit-card-number containers should be at least 340px wide, pay-theory-credit-card combined input should be 400px*
+_Individual pay-theory-credit-card-number containers should be at least 340px wide, pay-theory-credit-card combined input should be 400px_
 
 ```css
 #pay-theory-credit-card-number,
@@ -161,61 +150,135 @@ To style the input parent div simply provide your own CSS for the pay theory con
 }
 ```
 
-## Styles Object
+### Styles Object
 
-To style the input fields you can pass in a custom style object to the create function in our SDK. This allows you to style the text inside the inputs as well as the style of the radio buttons for the ACH account type
+To style the input fields you can pass in a custom style object to the create function in our SDK. The style object accepts a fixed set of keys — any property not listed in the tables below is silently ignored.
 
 ```javascript
 const STYLES = {
   default: {
     color: 'black',
-    fontSize: '14px'
+    fontSize: '14px',
+    fontFamily: 'Helvetica, Arial, sans-serif',
+    padding: '10px',
+    border: '1px solid #ccc',
+    borderRadius: '4px',
+    backgroundColor: '#ffffff',
   },
   success: {
     color: '#5cb85c',
-    fontSize: '14px'
+    borderColor: '#5cb85c',
   },
   error: {
     color: '#d9534f',
-    fontSize: '14px'
+    borderColor: '#d9534f',
   },
   radio: {
     width: 18,
-    fill: "blue",
-    stroke: "grey",
-    text: {
-      fontSize: "18px",
-      color: "grey"
-    }
+    fill: 'blue',
+    stroke: 'grey',
+    textFontSize: '14px',
+    textColor: 'grey',
+    textFontFamily: 'Helvetica, Arial, sans-serif',
   },
-  hidePlaceholder: false
-}
+  button: {
+    color: 'PURPLE',
+    callToAction: 'PAY',
+    pill: false,
+    height: 48,
+  },
+  hidePlaceholder: false,
+};
 ```
 
-|Key                | type                          |       description                     |
-|-------------------|-------------------------------|---------------------------------------|
-|default            | CSS Style Object              |The way a text field look when it is not in state success or error.|
-|success            | CSS Style Object              |The way a text field look when it is valid. Only applies to fields that go through validation.|
-|error              | CSS Style Object              |The way a text field look when it is invalid. Only applies to fields that go through validation.|
-|radio              | [Radio Object](#radio-object) |The way radio buttons look for the ACH account type|
-|hidePlaceholder    | Boolean                       |that allows you to hide the placeholder text in the input fields|
+| Key               | type                                      | description                                                                                                                                    |
+| ----------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default`         | [Field Style Object](#field-style-object) | Styling applied to text inputs when not in `success` or `error` state.                                                                         |
+| `success`         | [Field Style Object](#field-style-object) | Styling applied to text inputs that pass validation. Merged on top of `default` — any property not set here falls back to its `default` value. |
+| `error`           | [Field Style Object](#field-style-object) | Styling applied to text inputs that fail validation. Merged on top of `default` — same fallback behavior as `success`.                         |
+| `radio`           | [Radio Object](#radio-object)             | Styling for the ACH account-type radio buttons.                                                                                                |
+| `button`          | [Button Object](#button-object)           | Styling for the hosted checkout button.                                                                                                        |
+| `hidePlaceholder` | Boolean                                   | When `true`, the placeholder text in the input fields is hidden. Defaults to `false`.                                                          |
 
-## Radio Object
+### Field Style Object
 
-This style object will be used to style the labels for the radio buttons. It contains the following keys:
+The `default`, `success`, and `error` keys each accept the same 18 properties. All values are CSS strings.
 
-|Key                | type                        |       description                     |
-|-------------------|-----------------------------|---------------------------------------|
-|width              | Int                         |The width in pixels of the radio buttons|
-|fill               | String                      |The color of the radio buttons|
-|stroke             | String                      |The color of the radio buttons border|
-|text               | [Text Object](#text-object) |This style object will be used to style the labels for the radio buttons|
+| Key                | type   | description                                                                                                                                                   |
+| ------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `color`            | String | Text color. Accepts hex, `rgb()` / `rgba()`, `hsl()` / `hsla()`, named colors, CSS variables (`var(--x)`), `transparent`, `inherit`.                          |
+| `fontSize`         | String | Font size. Numeric + unit (`px`, `em`, `rem`, `%`, `vh`, `vw`, `pt`, `pc`, `in`, `cm`, `mm`, `ex`, `ch`, `vmin`, `vmax`), or `calc(...)`, `var(...)`, `auto`. |
+| `fontFamily`       | String | Font family stack. Capped at 100 characters.                                                                                                                  |
+| `lineHeight`       | String | CSS `line-height` value.                                                                                                                                      |
+| `padding`          | String | CSS `padding` shorthand. Same unit rules as `fontSize`.                                                                                                       |
+| `margin`           | String | CSS `margin` shorthand. Same unit rules as `fontSize`.                                                                                                        |
+| `textAlign`        | String | CSS `text-align` value (`left`, `right`, `center`, `justify`, `start`, `end`).                                                                                |
+| `border`           | String | CSS `border` shorthand (e.g. `'1px solid #ccc'`).                                                                                                             |
+| `borderColor`      | String | Border color only. Same value rules as `color`.                                                                                                               |
+| `borderRadius`     | String | CSS `border-radius` value.                                                                                                                                    |
+| `backgroundColor`  | String | Background color. Same value rules as `color`.                                                                                                                |
+| `boxShadow`        | String | CSS `box-shadow` value.                                                                                                                                       |
+| `outline`          | String | CSS `outline` shorthand.                                                                                                                                      |
+| `width`            | String | CSS `width`. Same unit rules as `fontSize`.                                                                                                                   |
+| `height`           | String | CSS `height`. Same unit rules as `fontSize`.                                                                                                                  |
+| `transition`       | String | CSS `transition` shorthand.                                                                                                                                   |
+| `opacity`          | String | CSS `opacity` (`'0'`–`'1'`).                                                                                                                                  |
+| `webkitAppearance` | String | CSS `-webkit-appearance` value.                                                                                                                               |
 
-## Text Object
+### Radio Object
 
-This style object will be used to style the labels for the radio buttons. It contains the following keys:
+Styles for the ACH account-type radio buttons. Both the flat properties and the legacy nested `text` object are supported; if both forms are set, the nested values take precedence.
 
-|Key                |type         |       description                     |
-|-------------------|-------------|---------------------------------------|
-|fontSize           |String       |The font size of the radio button labels|
-|color              |String       |The color of the radio button labels|
+| Key              | type                        | description                                                        |
+| ---------------- | --------------------------- | ------------------------------------------------------------------ |
+| `width`          | Int \| String               | Width of the radio button. Bare numbers are interpreted as pixels. |
+| `fill`           | String                      | Fill color of the selected indicator.                              |
+| `stroke`         | String                      | Color of the radio outline.                                        |
+| `textFontSize`   | String                      | Font size for the radio label.                                     |
+| `textColor`      | String                      | Color for the radio label.                                         |
+| `textFontFamily` | String                      | Font family for the radio label.                                   |
+| `text`           | [Text Object](#text-object) | Backwards-compatible nested form for label styling.                |
+
+### Text Object
+
+Backwards-compatible nested form for styling the radio button labels.
+
+| Key          | type   | description                             |
+| ------------ | ------ | --------------------------------------- |
+| `fontSize`   | String | Font size of the radio button labels.   |
+| `color`      | String | Color of the radio button labels.       |
+| `fontFamily` | String | Font family of the radio button labels. |
+| `fontWeight` | String | Font weight of the radio button labels. |
+
+### Button Object
+
+Styles for the hosted checkout button. The button accepts a **config** form (preset color and call-to-action — the common case) or a **processed** form where you set the resolved CSS properties directly.
+
+**Config form**
+
+| Key            | type                                              | description                                                                     |
+| -------------- | ------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `color`        | `'PURPLE'` \| `'WHITE'` \| `'BLACK'` \| `'GREY'`  | Preset color theme. Matching is case-insensitive. Defaults to `'PURPLE'`.       |
+| `callToAction` | `'PAY'` \| `'CHECKOUT'` \| `'DONATE'` \| `'BOOK'` | Sets the button copy (e.g. `'PAY'` → "Pay with"). Matching is case-insensitive. |
+| `pill`         | Boolean                                           | When `true`, gives the button a fully rounded (pill) shape.                     |
+| `height`       | Int \| String                                     | Button height. Numbers are interpreted as pixels.                               |
+
+**Processed form**
+
+| Key               | type   | description                                                       |
+| ----------------- | ------ | ----------------------------------------------------------------- |
+| `backgroundColor` | String | Button background color. Default: `#9139D2`.                      |
+| `borderRadius`    | String | Button corner radius. Default: `4px` (`100px` when `pill: true`). |
+| `fontColor`       | String | Button text color. Default: `#FFFFFF`.                            |
+| `height`          | String | Button height. Default: `48px`.                                   |
+| `border`          | String | CSS `border` shorthand (e.g. `'0.5px solid #C9C4CA'`).            |
+| `altText`         | String | Accessible label / button copy.                                   |
+
+**Defaults applied by preset `color`**
+
+| `color`  | background | text color | border                |
+| -------- | ---------- | ---------- | --------------------- |
+| `PURPLE` | `#9139D2`  | `#FFFFFF`  | none                  |
+| `BLACK`  | `#000000`  | `#FFFFFF`  | none                  |
+| `WHITE`  | `#FFFFFF`  | `#000000`  | `0.5px solid #C9C4CA` |
+| `GREY`   | `#F7F7F4`  | `#000000`  | none                  |


### PR DESCRIPTION
## Summary

Replaces the partial JS SDK styles documentation with the full enumeration of keys that `secure-tags-lib` actually accepts, in both production and lab docs.

- 18 supported field properties across `default` / `success` / `error` states, with per-property type and allowed-value notes
- Documents the inheritance behavior (`success` and `error` merge on top of `default`)
- Adds the flat radio properties (`textFontSize`, `textColor`, `textFontFamily`) alongside the legacy nested `text` form
- Adds the **Button object** — previously undocumented entirely — covering both the config form (preset `color`, `callToAction`, `pill`, `height`) and processed form, plus a table of defaults each preset applies
- Notes that any unlisted property is silently ignored
- In `hosted_fields.md`, demotes the per-object headings (`Styles Object`, `Field Style Object`, `Radio Object`, `Text Object`, `Button Object`) to H3 so they nest under "Styling Hosted Fields" in the sidebar

Linear: [PRD-319](https://linear.app/pay-theory/issue/PRD-319/better-document-allowed-values-for-the-js-sdk-styles-object)

## Test plan

- [x] `npm run build` succeeds
- [x] `npx prettier --check` passes on all four modified files
- [ ] Visually verify the styling guide page in `npm start` (JavaScript tab)
- [ ] Visually verify the SDK reference page — confirm the five new H3 subsections nest under "Styling Hosted Fields" in the sidebar
- [ ] Spot-check that in-page anchor links (e.g. `#field-state-properties`, `#radio-object`, `#button-object`) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)