### PR TITLE
📝 docs(webhooks): add webhook receiving guide

### DIFF
--- a/docs/main/after_payments/webhook_events.mdx
+++ b/docs/main/after_payments/webhook_events.mdx
@@ -6,7 +6,7 @@ title: Webhooks
 
 # Webhooks
 
-Pay Theory webhooks send an HTTP `POST` to your application when a Pay Theory event happens. Use them when your system needs to react after the payment flow, such as syncing transactions, storing new payors, updating saved payment methods, or tracking disputes.
+Pay Theory webhooks send an HTTP `POST` to your application when a Pay Theory event happens. Use them when your system needs to react after the payment flow, such as syncing merchants, transactions, settlements, payors, saved payment methods, or disputes.
 
 For copy/paste JSON payloads, see [Webhook Sample Payloads](webhook_sample_payloads).
 
@@ -46,17 +46,17 @@ Every Pay Theory webhook uses this top-level shape:
 
 | Field | Type | Description |
 |---|---|---|
-| `event` | string | The event family, such as `MERCHANT`, `PAYOR`, or `PAYMENT_METHOD`. |
-| `subtype` | string | The event action or state, such as `CREATED`, `UPDATED`, or `DELETED`. |
+| `event` | string | The event family, such as `MERCHANT`, `TRANSACTION`, or `PAYMENT_METHOD`. |
+| `subtype` | string | The event action or state, such as `CREATED` or `UPDATED`. |
 | `payload` | object | The event-specific data object. |
 
 Example:
 
 ```json
 {
-    "event": "PAYOR",
-    "subtype": "CREATED",
-    "payload": {
+  "event": "PAYOR",
+  "subtype": "CREATED",
+  "payload": {
     "payor_id": "payor_123",
     "merchant_uid": "mer_123",
     "email": "jane@example.com"
@@ -94,6 +94,8 @@ The currently confirmed webhook event families are:
 | Event | Documented subtypes | Description |
 |---|---|---|
 | `AUTHORIZATION` | `CREATED`, `UPDATED` | Authorization activity was emitted. |
+| `MERCHANT` | `CREATED`, `UPDATED` | A merchant record was created or updated. |
+| `SETTLEMENT` | `CREATED`, `UPDATED` | Settlement activity was emitted. |
 | `TRANSACTION` | `CREATED`, `UPDATED` | Transaction activity was emitted. |
 | `SPLIT_FUNDING` | `CREATED`, `UPDATED` | Split funding activity was emitted. |
 | `PAYOR` | `CREATED`, `UPDATED` | A payor record was created or updated. |

--- a/docs/main/after_payments/webhook_events.mdx
+++ b/docs/main/after_payments/webhook_events.mdx
@@ -1,0 +1,129 @@
+---
+sidebar_position: 8
+sidebar_label: Webhooks
+title: Webhooks
+---
+
+# Webhooks
+
+Pay Theory webhooks send an HTTP `POST` to your application when a Pay Theory event happens. Use them when your system needs to react after the payment flow, such as syncing transactions, storing new payors, updating saved payment methods, or tracking disputes.
+
+For copy/paste JSON payloads, see [Webhook Sample Payloads](webhook_sample_payloads).
+
+***
+
+## Before You Start
+
+Make sure you have:
+
+- A public HTTPS endpoint that Pay Theory can reach.
+- A server route that accepts `POST` requests.
+- JSON body parsing enabled on that route.
+- A way to return a quick `2xx` response after receiving the event.
+- Retry-safe handling so duplicate deliveries do not create duplicate side effects.
+- Separate webhook URLs for sandbox/testing and production.
+- Basic logging for webhook request bodies while testing.
+
+If you are testing locally, use a public tunnel such as ngrok or a request inspection tool such as RequestBin. A `localhost` URL will not work because Pay Theory cannot reach your machine directly.
+
+***
+
+## How It Works
+
+1. An event happens in Pay Theory.
+2. Pay Theory sends your endpoint an HTTP `POST`.
+3. Your endpoint reads the JSON body.
+4. Your endpoint returns a `2xx` response.
+5. Your application processes the event.
+
+Process the event idempotently. In practice, that means your code should be safe if the same payload is received more than once.
+
+***
+
+## Webhook Request Shape
+
+Every Pay Theory webhook uses this top-level shape:
+
+| Field | Type | Description |
+|---|---|---|
+| `event` | string | The event family, such as `MERCHANT`, `PAYOR`, or `PAYMENT_METHOD`. |
+| `subtype` | string | The event action or state, such as `CREATED`, `UPDATED`, or `DELETED`. |
+| `payload` | object | The event-specific data object. |
+
+Example:
+
+```json
+{
+    "event": "PAYOR",
+    "subtype": "CREATED",
+    "payload": {
+    "payor_id": "payor_123",
+    "merchant_uid": "mer_123",
+    "email": "jane@example.com"
+  }
+}
+```
+
+Use `event` and `subtype` to route the webhook in your application. Use `payload` for the event data.
+
+***
+
+## Create A Webhook
+
+You can manage webhooks from the Pay Theory portal or through the GraphQL API.
+
+When creating a webhook, provide:
+
+- `endpoint`: the HTTPS URL Pay Theory should call.
+- `name`: a human-readable name for the webhook.
+
+API references:
+
+- [Create Webhook](../../api/webhooks/create-webhook)
+- [List Webhooks](../../api/webhooks)
+- [Update Webhook](../../api/webhooks/update-webhook)
+- [Delete Webhook](../../api/webhooks/delete-webhook)
+- [List Webhook Events](../../api/webhooks/webhook-events)
+
+***
+
+## Event Types
+
+The currently confirmed webhook event families are:
+
+| Event | Documented subtypes | Description |
+|---|---|---|
+| `AUTHORIZATION` | `CREATED`, `UPDATED` | Authorization activity was emitted. |
+| `TRANSACTION` | `CREATED`, `UPDATED` | Transaction activity was emitted. |
+| `SPLIT_FUNDING` | `CREATED`, `UPDATED` | Split funding activity was emitted. |
+| `PAYOR` | `CREATED`, `UPDATED` | A payor record was created or updated. |
+| `PAYMENT_METHOD` | `CREATED`, `UPDATED` | A payment method token record was created or updated. |
+| `DISPUTE` | `CREATED`, `UPDATED` | Dispute activity was emitted. |
+
+See [Webhook Sample Payloads](webhook_sample_payloads) for documented field tables and JSON examples.
+
+***
+
+## Testing Webhooks
+
+Use this checklist when testing:
+
+- Create a webhook that points to a test endpoint.
+- Trigger an event in the sandbox environment.
+- Confirm your endpoint receives a `POST`.
+- Confirm the body has `event`, `subtype`, and `payload`.
+- Return a `2xx` response from your endpoint.
+- Check [webhookEvents](../../api/webhooks/webhook-events) if you need delivery history.
+- Confirm your application does not duplicate work if the same event is processed more than once.
+
+***
+
+## Troubleshooting
+
+| Problem | What to check |
+|---|---|
+| You are not receiving events | Confirm the webhook is active and the endpoint is public HTTPS. |
+| Local testing does not work | Use a public tunnel or request inspection URL instead of `localhost`. |
+| Pay Theory reports delivery failures | Confirm your endpoint returns a `2xx` response without timing out. |
+| The payload is not what you expected | Check the `event` and `subtype`, then compare against the sample payload page. |
+| Your system creates duplicates | Add idempotency handling before creating records or triggering side effects. |

--- a/docs/main/after_payments/webhook_sample_payloads.mdx
+++ b/docs/main/after_payments/webhook_sample_payloads.mdx
@@ -89,6 +89,72 @@ This example is abbreviated. Real transaction payloads may include additional ne
 
 ***
 
+## MERCHANT
+
+Merchant webhooks notify your endpoint when a merchant record is created or updated.
+Hard deletes are not currently documented as webhook events.
+
+### Payload Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `merchant_uid` | string | Unique merchant identifier. |
+| `merchant_name` | string | Merchant display name. |
+| `is_system` | boolean | Whether this is a system merchant. |
+| `country_code` | string, optional | Merchant country code. |
+| `parent_merchant_uid` | string, optional | Parent merchant identifier when nested. |
+| `ach_active` | boolean, optional | Whether ACH payments are active. |
+| `card_active` | boolean, optional | Whether card payments are active. |
+| `cash_active` | boolean, optional | Whether cash payments are active. |
+| `submitted_onboarding` | boolean, optional | Whether onboarding has been submitted. |
+| `settings` | object, optional | Merchant profile, social, or contact settings. |
+
+### MERCHANT.CREATED
+
+```json
+{
+  "event": "MERCHANT",
+  "subtype": "CREATED",
+  "payload": {
+    "merchant_uid": "mer_123",
+    "merchant_name": "Acme Store",
+    "is_system": false,
+    "country_code": "USA",
+    "ach_active": true,
+    "card_active": true,
+    "cash_active": false,
+    "submitted_onboarding": false
+  }
+}
+```
+
+### MERCHANT.UPDATED
+
+```json
+{
+  "event": "MERCHANT",
+  "subtype": "UPDATED",
+  "payload": {
+    "merchant_uid": "mer_123",
+    "merchant_name": "Acme Store",
+    "is_system": false,
+    "country_code": "USA",
+    "parent_merchant_uid": null,
+    "ach_active": true,
+    "card_active": true,
+    "cash_active": false,
+    "submitted_onboarding": true,
+    "settings": {
+      "contact_email": "ops@acme.com",
+      "contact_phone": "+18005551212",
+      "website": "https://paytheory.com"
+    }
+  }
+}
+```
+
+***
+
 ## PAYOR
 
 Payor webhooks notify your endpoint when a payor record is created or updated.
@@ -130,8 +196,6 @@ Payor webhooks notify your endpoint when a payor record is created or updated.
   }
 }
 ```
-
-***
 
 ## PAYMENT_METHOD
 

--- a/docs/main/after_payments/webhook_sample_payloads.mdx
+++ b/docs/main/after_payments/webhook_sample_payloads.mdx
@@ -1,0 +1,196 @@
+---
+sidebar_position: 9
+sidebar_label: Webhook Sample Payloads
+title: Webhook Sample Payloads
+---
+
+# Webhook Sample Payloads
+
+This page contains representative JSON examples for webhook payloads whose shape has been verified.
+
+Some webhook payloads include large nested objects. The examples below keep the important shape and common fields visible without showing every nullable field.
+
+Each webhook has the same top-level envelope:
+
+```json
+{
+  "event": "PAYOR",
+  "subtype": "CREATED",
+  "payload": {}
+}
+```
+
+The `payload` fields depend on the `event` and `subtype`.
+
+***
+
+## TRANSACTION
+
+Transaction webhooks notify your endpoint when transaction activity is emitted.
+
+### Payload Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `transaction_id` | string | Unique transaction identifier. |
+| `transaction_type` | string | Transaction type, such as `DEBIT`. |
+| `status` | string | Current transaction status. |
+| `gross_amount` | number | Total transaction amount in cents. |
+| `fees` | number | Fee amount in cents. |
+| `net_amount` | number | Net amount in cents. |
+| `currency` | string | Transaction currency. |
+| `merchant_uid` | string | Merchant identifier associated with the transaction. |
+| `transaction_date` | string | Transaction timestamp. |
+| `metadata` | string | JSON string of transaction metadata. |
+| `merchant` | object | Merchant details included with the transaction. |
+| `payment_method` | object | Payment method details included with the transaction. |
+| `invoice` | object | Invoice details when the transaction is connected to an invoice. |
+| `recurring` | object | Recurring payment details when the transaction is connected to a recurring payment. |
+
+### TRANSACTION.CREATED
+
+This example is abbreviated. Real transaction payloads may include additional nested fields and nullable values.
+
+```json
+{
+  "event": "TRANSACTION",
+  "subtype": "CREATED",
+  "payload": {
+    "transaction_id": "ptl_txn_123",
+    "transaction_type": "DEBIT",
+    "status": "PENDING",
+    "gross_amount": 102,
+    "fees": 33,
+    "net_amount": 69,
+    "currency": "USD",
+    "merchant_uid": "mer_123",
+    "transaction_date": "2026-07-29T18:41:48.0Z",
+    "metadata": "{\"pay_theory_reference\":\"field-trip\"}",
+    "merchant": {
+      "merchant_uid": "mer_123",
+      "merchant_name": "Acme Store",
+      "country_code": "USA"
+    },
+    "payment_method": {
+      "payment_method_id": "ptl_pmt_123",
+      "payment_type": "CARD",
+      "card_brand": "MASTERCARD",
+      "card_type": "DEBIT_CARD",
+      "last_four": "6767",
+      "payor": {
+        "payor_id": "ptl_pay_123",
+        "full_name": "Jane Doe",
+        "email": "jane@example.com"
+      }
+    }
+  }
+}
+```
+
+***
+
+## PAYOR
+
+Payor webhooks notify your endpoint when a payor record is created or updated.
+
+### Payload Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `payor_id` | string | Unique payor identifier. |
+| `merchant_uid` | string | Merchant identifier associated with the payor. |
+| `full_name` | string, optional | Payor full name. |
+| `email` | string, optional | Payor email address. |
+| `phone` | string, optional | Payor phone number. |
+| `address_line1` | string, optional | Primary street address. |
+| `address_line2` | string, optional | Secondary street address. |
+| `city` | string, optional | City. |
+| `region` | string, optional | State or region. |
+| `postal_code` | string, optional | Postal or ZIP code. |
+| `country` | string, optional | Country code or name. |
+
+### PAYOR.CREATED
+
+```json
+{
+  "event": "PAYOR",
+  "subtype": "CREATED",
+  "payload": {
+    "payor_id": "payor_123",
+    "merchant_uid": "mer_123",
+    "full_name": "Jane Doe",
+    "email": "jane@example.com",
+    "phone": "+18005550000",
+    "address_line1": "123 Main St",
+    "address_line2": "Suite 100",
+    "city": "Austin",
+    "region": "TX",
+    "postal_code": "78701",
+    "country": "USA"
+  }
+}
+```
+
+***
+
+## PAYMENT_METHOD
+
+Payment method webhooks notify your endpoint when a payment method token record is created.
+Payment method updates use the same event family with the `UPDATED` subtype.
+
+### Payload Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `payment_method_id` | string | Unique payment method identifier. |
+| `merchant_uid` | string | Merchant identifier associated with the payment method. |
+| `payor_id` | string, optional | Associated payor identifier. |
+| `payment_type` | string, optional | Payment type or category. |
+| `card_brand` | string, optional | Card brand for card payment methods. |
+| `card_type` | string, optional | Card type, such as credit or debit. |
+| `exp_date` | string, optional | Expiration date in the source format. |
+| `last_four` | string, optional | Last four digits. |
+| `cvv_status` | string, optional | CVV verification status. |
+| `bank_account_type` | string, optional | Bank account type for ACH payment methods. |
+| `bank_code` | string, optional | Bank routing number or bank code. |
+| `wallet_type` | string, optional | Wallet provider or type. |
+| `barcode_id` | string, optional | Barcode identifier for cash payment flows. |
+| `processor` | string, optional | Upstream processor name. |
+| `processor_token` | string, optional | Processor token or reference. |
+| `paytheory_encoded` | string, optional | Encoded Pay Theory value or token. |
+| `issuing_country_code` | string, optional | Issuing country code. |
+| `is_active` | boolean, optional | Whether the payment method is active. |
+| `full_name` | string, optional | Cardholder or account holder name. |
+| `address_line1` | string, optional | Billing address line 1. |
+| `address_line2` | string, optional | Billing address line 2. |
+| `city` | string, optional | Billing city. |
+| `region` | string, optional | Billing state or region. |
+| `postal_code` | string, optional | Billing postal or ZIP code. |
+| `country` | string, optional | Billing country. |
+
+### PAYMENT_METHOD.CREATED
+
+```json
+{
+  "event": "PAYMENT_METHOD",
+  "subtype": "CREATED",
+  "payload": {
+    "payment_method_id": "pmt_123",
+    "merchant_uid": "mer_123",
+    "payor_id": "payor_123",
+    "payment_type": "CARD",
+    "card_brand": "VISA",
+    "card_type": "CREDIT",
+    "exp_date": "12/29",
+    "last_four": "4242",
+    "cvv_status": "MATCH",
+    "is_active": true,
+    "full_name": "Jane Doe",
+    "address_line1": "123 Main St",
+    "city": "Austin",
+    "region": "TX",
+    "postal_code": "78701",
+    "country": "USA"
+  }
+}
+```

--- a/docs/main/testing.mdx
+++ b/docs/main/testing.mdx
@@ -86,3 +86,5 @@ These GraphQL requests are specifically for testing in sandbox environments and 
 
 - [Create Barcode Payment](../api/sandbox/create-barcode-payment-sandbox) - Simulate processing a barcode payment
 - [Create Batch Capture](../api/sandbox/create-batch-capture) - Trigger a settlement batch creation to test settlement flows
+
+For webhook setup and payload examples, see [Webhooks](after_payments/webhook_events).


### PR DESCRIPTION
## Summary
- Add a Webhooks guide with prerequisites, request shape, setup, event families, receiver example, testing, and troubleshooting
- Add webhook sample payload reference with verified TRANSACTION, PAYOR, and PAYMENT_METHOD examples
- Link sandbox testing docs to the new Webhooks guide

## Testing
- npm run build

## Notes
- PR targets pt-paytheory as requested.